### PR TITLE
Fix: Clear error feedback when API quota is reached

### DIFF
--- a/src/Components/DownloadButton.jsx
+++ b/src/Components/DownloadButton.jsx
@@ -1,4 +1,4 @@
-export default function DownloadButton({ 
+ export default function DownloadButton({ 
   enhancedFileBase64,
   fileFormat
 }) {

--- a/src/hooks/gemini.js
+++ b/src/hooks/gemini.js
@@ -41,6 +41,8 @@ async function parsePDF(file) {
     
     return text.trim();
   } catch (error) {
+    
+
     console.error("PDF parsing error:", error);
     throw new Error(`PDF parsing failed: ${error.message}`);
   }
@@ -399,7 +401,13 @@ enhancedResumeOnly = enhancedResumeOnly
     };
     
   } catch (error) {
-    console.error('Gemini API Error:', error.response?.data || error.message);
+        console.error('Gemini API Error:', error.response?.data || error.message);
+
+    const errorResponse=error.response;
+     if (errorResponse && errorResponse.status ===429){
+     throw new Error(`AI enhancement failed API Limit Reached.Please wait and try again. `);
+     }
+
     throw new Error(error.response?.data?.error?.message || error.message || "AI enhancement failed");
   }
 }


### PR DESCRIPTION
I have made a errorResponse which catches the (error.response) and if it exist and is equal to our 429(which is api quota reached )then throws a new error which explains what happened to user 