### PR TITLE
Add French/Spanish resume support: i18n, Gemini prompt language handl…

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,7 +3,8 @@ import EliteHeader from "./Components/EliteHeader";
 import FileUpload from "./Components/FileUpload";
 import EnhancementViewer from "./Components/EnhancementViewer";
 import DownloadButton from "./Components/DownloadButton";
-import './i18n';
+import LanguageSwitcher from "./Components/LanguageSwitcher";
+import './i18n/config';
 export default function App() {
   const [resumeFile, setResumeFile] = useState(null);
   const [enhancedText, setEnhancedText] = useState("");
@@ -13,6 +14,9 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-blue-100 flex flex-col items-center px-2">
       <EliteHeader />
+      <div className="mt-4 mb-6">
+        <LanguageSwitcher />
+      </div>
       <main className="flex-1 w-full max-w-2xl mx-auto flex flex-col items-center justify-center">
         {!resumeFile ? (
           <FileUpload setResumeFile={setResumeFile} />

--- a/src/hooks/gemini.js
+++ b/src/hooks/gemini.js
@@ -241,13 +241,47 @@ function generateTXT(enhancedResumeText) {
 
 export async function enhanceResumeWithGemini(resumeText, format, uploaderName, language) {
   
-  const languageInstructions = {
-    en: "Respond in English.",
-    fr: "Réponds en français.",
-    es: "Responde en español.",
+  const languageConfig = {
+    en: {
+      instruction: "Respond in English.",
+      sectionHeadings: {
+        summary: "Professional Summary",
+        experience: "Work Experience",
+        education: "Education",
+        skills: "Skills",
+        languages: "Languages",
+        achievements: "Achievements",
+        certifications: "Certifications"
+      }
+    },
+    fr: {
+      instruction: "Réponds en français. Traduis tous les titres de sections et le contenu en français.",
+      sectionHeadings: {
+        summary: "Résumé Professionnel",
+        experience: "Expérience Professionnelle",
+        education: "Formation",
+        skills: "Compétences",
+        languages: "Langues",
+        achievements: "Réalisations",
+        certifications: "Certifications"
+      }
+    },
+    es: {
+      instruction: "Responde en español. Traduce todos los títulos de secciones y el contenido al español.",
+      sectionHeadings: {
+        summary: "Resumen Profesional",
+        experience: "Experiencia Profesional",
+        education: "Educación",
+        skills: "Habilidades",
+        languages: "Idiomas",
+        achievements: "Logros",
+        certifications: "Certificaciones"
+      }
+    }
   };
   
-  const langInstruction = languageInstructions[language] || languageInstructions.en;
+  const config = languageConfig[language] || languageConfig.en;
+  const sectionHeadings = Object.values(config.sectionHeadings).join('|');
 
   if (!resumeText || resumeText.trim() === "") {
     throw new Error("Resume text is empty");
@@ -255,11 +289,13 @@ export async function enhanceResumeWithGemini(resumeText, format, uploaderName, 
 
   const prompt = `
 You are an expert ATS (Applicant Tracking System) resume optimizer. Analyze and enhance the following resume.
-${langInstruction}
+${config.instruction}
 CRITICAL INSTRUCTIONS - FOLLOW EXACTLY:
-1. First provide ATS analysis with scores
+1. First provide ATS analysis with scores in the selected language
 2. Then add the marker: ###RESUME_START###
 3. After the marker, provide ONLY the clean enhanced resume (no scores, no analysis, no explanations)
+4. Make sure to translate all section headings to match exactly: ${Object.values(config.sectionHeadings).join(', ')}
+5. Ensure all content is properly translated and maintains professional tone in the target language
 
 OUTPUT FORMAT:
 === ATS ANALYSIS ===

--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -1,0 +1,151 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      en: {
+        translation: {
+          header: {
+            title: "AI Resume Enhancer",
+            subtitle: "Intelligent ATS‑Optimized Resume Enhancer"
+          },
+          upload: {
+            title: "Upload your resume as",
+            or: "or",
+            here: "here",
+            button: "Upload",
+            note: "We accept PDF, DOCX and TXT files"
+          },
+          enhancing: {
+            title: "Enhancing your resume",
+            subtitle: "AI is improving formatting and ATS compatibility"
+          },
+          errors: {
+            title: "Error",
+            noText: "No text could be extracted from the uploaded file.",
+            generic: "Something went wrong. Please try again."
+          },
+          enhanced: {
+            heading: "Enhanced Resume"
+          },
+          resume: {
+            sections: {
+              summary: "Professional Summary",
+              experience: "Work Experience",
+              education: "Education",
+              skills: "Skills",
+              languages: "Languages",
+              achievements: "Achievements",
+              projects: "Projects",
+              certifications: "Certifications"
+            },
+            labels: {
+              present: "Present",
+              years: "years",
+              months: "months",
+              now: "Now"
+            }
+          }
+        }
+      },
+      fr: {
+        translation: {
+          header: {
+            title: "Améliorateur de CV IA",
+            subtitle: "Optimisation intelligente des CV pour les ATS"
+          },
+          upload: {
+            title: "Téléversez votre CV en",
+            or: "ou",
+            here: "ici",
+            button: "Téléverser",
+            note: "Nous acceptons les fichiers PDF, DOCX et TXT"
+          },
+          enhancing: {
+            title: "Amélioration de votre CV",
+            subtitle: "L'IA améliore la mise en forme et la compatibilité ATS"
+          },
+          errors: {
+            title: "Erreur",
+            noText: "Aucun texte n'a pu être extrait du fichier téléversé.",
+            generic: "Une erreur est survenue. Veuillez réessayer."
+          },
+          enhanced: {
+            heading: "CV Amélioré"
+          },
+          resume: {
+            sections: {
+              summary: "Résumé Professionnel",
+              experience: "Expérience Professionnelle",
+              education: "Formation",
+              skills: "Compétences",
+              languages: "Langues",
+              achievements: "Réalisations",
+              projects: "Projets",
+              certifications: "Certifications"
+            },
+            labels: {
+              present: "Présent",
+              years: "ans",
+              months: "mois",
+              now: "Maintenant"
+            }
+          }
+        }
+      },
+      es: {
+        translation: {
+          header: {
+            title: "Mejorador de CV con IA",
+            subtitle: "Optimización inteligente de CV para ATS"
+          },
+          upload: {
+            title: "Sube tu currículum en",
+            or: "o",
+            here: "aquí",
+            button: "Subir",
+            note: "Aceptamos archivos PDF, DOCX y TXT"
+          },
+          enhancing: {
+            title: "Mejorando tu currículum",
+            subtitle: "La IA mejora el formato y la compatibilidad con ATS"
+          },
+          errors: {
+            title: "Error",
+            noText: "No se pudo extraer texto del archivo subido.",
+            generic: "Algo salió mal. Por favor, inténtalo de nuevo."
+          },
+          enhanced: {
+            heading: "Currículum Mejorado"
+          },
+          resume: {
+            sections: {
+              summary: "Resumen Profesional",
+              experience: "Experiencia Profesional",
+              education: "Educación",
+              skills: "Habilidades",
+              languages: "Idiomas",
+              achievements: "Logros",
+              projects: "Proyectos",
+              certifications: "Certificaciones"
+            },
+            labels: {
+              present: "Presente",
+              years: "años",
+              months: "meses",
+              now: "Actualidad"
+            }
+          }
+        }
+      }
+    },
+    lng: "en", // default language
+    fallbackLng: "en",
+    interpolation: {
+      escapeValue: false
+    }
+  });
+
+export default i18n;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./styles/tailwind.css";
+import "./i18n/config";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>

--- a/src/utils/resumeTemplate.js
+++ b/src/utils/resumeTemplate.js
@@ -10,13 +10,13 @@ function escapeHtml(text) {
 /**
  * Wraps the plain AI-enhanced resume text into an elite professional HTML resume template.
  */
-export function generateEliteResumeHTML(enhancedText) {
-    console.log("Enhanced text for PDF:",enhancedText)
+export function generateEliteResumeHTML(enhancedText, language = 'en') {
+  console.log("Enhanced text for PDF:",enhancedText)
   const safeText = escapeHtml(enhancedText).replace(/\n/g, "<br>");
 
   return `
 <!DOCTYPE html>
-<html lang="en">
+<html lang="${language}">
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Summary
solves #13 
Add first-class support for generating resumes in French and Spanish.
Ensure UI strings exist for en/fr/es and the Gemini prompt produces enhanced resume text in the selected language.
Make the HTML resume template accept a language parameter and set the <html lang=""> attribute.
please let me know if any changes are needed